### PR TITLE
Fix of moveTail method

### DIFF
--- a/src/PyLOB/orderlist.py
+++ b/src/PyLOB/orderlist.py
@@ -71,8 +71,8 @@ class OrderList(object):
         order.nextOrder.prevOrder = order.prevOrder
         # Set the previous tail order's next order to this order
         self.tailOrder.nextOrder = order
-        self.tailOrder = order
         order.prevOrder = self.tailOrder
+        self.tailOrder = order
         order.nextOrder = None
         
     def __str__(self):


### PR DESCRIPTION
Method moveTail in orderlist is not implemented correctly and could lead to situation when order.nextOrder is referring to itself (and cause infinite loop when iterating over orderlist), it is sufficient to swap lines at the end of the method such that firstly order.prevOrder is set to point to current tailOrder and after that tailOrder is changed to point to order.